### PR TITLE
Add ions while moving window is on; mw_mcr

### DIFF
--- a/quill3d-conf/example/quill.conf.example
+++ b/quill3d-conf/example/quill.conf.example
@@ -131,13 +131,15 @@ mwindow = off # default: on; possible: on, off, auto
 #mwtolerance = 1e-6 # default: 1e-6
 # moving window velocity
 #mwspeed = 0.4 # default: 1, игнорируется при mwindow = auto
-# включает или отключает добавление электронов на передней границе области
-# при работе движущегося окна; таким образом, при mw_mcr = 0 ионы считаюстя неподвижными
+# включает или отключает добавление электронов на передней границе области при работе движущегося
+# окна; таким образом, при mwseed_ions = off ионы считаюстя неподвижными
 #mwseed = on # default: on; possible: on, off
-# Mass-to-charge ratio of the ions (in that for the protons); turns ions on; if mwseed is on, and
-# mw_mcr is non-zero, such ions are added on the right boundary of the simulation box while the box
-# is moving.
-mw_mcr = 1 # default: 0
+# If turned on, ions are putted at the front (right) side of the simulation box while moving window
+# is working.
+#mwseed_ions = on # default: off; possible: on, off
+# Mass-to-charge ratio of the ions (in that for the protons) which are added on the right boundary
+# of the simulation box while the box is moving.
+#mw_mcr = 2 # default: 1
 
 # компоненты полей для вывода в файл
 e_components_for_output = xyz # default: none; possible: x, y, z, xy, xz, yz, xyz

--- a/quill3d-conf/example/quill.conf.example
+++ b/quill3d-conf/example/quill.conf.example
@@ -131,9 +131,13 @@ mwindow = off # default: on; possible: on, off, auto
 #mwtolerance = 1e-6 # default: 1e-6
 # moving window velocity
 #mwspeed = 0.4 # default: 1, игнорируется при mwindow = auto
-# включает или отключает добавление частиц на передней границе области
-# при работе движущегося окна
+# включает или отключает добавление электронов на передней границе области
+# при работе движущегося окна; таким образом, при mw_mcr = 0 ионы считаюстя неподвижными
 #mwseed = on # default: on; possible: on, off
+# Mass-to-charge ratio of the ions (in that for the protons); turns ions on; if mwseed is on, and
+# mw_mcr is non-zero, such ions are added on the right boundary of the simulation box while the box
+# is moving.
+mw_mcr = 1 # default: 0
 
 # компоненты полей для вывода в файл
 e_components_for_output = xyz # default: none; possible: x, y, z, xy, xz, yz, xyz

--- a/quill3d-conf/example/quill.conf.radiation-trapping
+++ b/quill3d-conf/example/quill.conf.radiation-trapping
@@ -51,13 +51,15 @@ a0y = 2500
 
 # движущееся окно; выключается при наличии нейтральных потоков (flows)
 mwindow = on # default: on; possible: on, off, auto
-# включает или отключает добавление электронов на передней границе области
-# при работе движущегося окна; таким образом, при mw_mcr = 0 ионы считаюстя неподвижными
+# включает или отключает добавление электронов на передней границе области при работе движущегося
+# окна; таким образом, при mwseed_ions = off ионы считаюстя неподвижными
 mwseed = on # default: on; possible: on, off
-# Mass-to-charge ratio of the ions (in that for the protons); turns ions on; if mwseed is on, and
-# mw_mcr is non-zero, such ions are added on the right boundary of the simulation box while the box
-# is moving.
-mw_mcr = 2 # default: 0
+# If turned on, ions are putted at the front (right) side of the simulation box while moving window
+# is working.
+mwseed_ions = on # default: off; possible: on, off
+# Mass-to-charge ratio of the ions (in that for the protons) which are added on the right boundary
+# of the simulation box while the box is moving.
+mw_mcr = 2 # default: 1
 
 
 # включение ионов (только для плёнок)

--- a/quill3d-conf/example/quill.conf.radiation-trapping
+++ b/quill3d-conf/example/quill.conf.radiation-trapping
@@ -1,0 +1,121 @@
+# This configuration demonstrates radiation trapping of electrons in a bubble-like structure, see
+# L.L. Ji, A.Pukhov et al, PRL 112, 145003 (2014) for a similar phenomenon.
+
+# число вычислительных потоков
+n_sr = 8 # default: 8
+
+# шаги численной сетки; если задан dt, но не задан dx, то dx
+# вычисляется автоматически так, чтобы алгоритм NDFX давал наименьшую
+# дисперсию, но был устойчив; если dt не задан, то он вычисляется как
+# половина критического для данной плотности шага по времени, после dx
+# вычисляется автоматически по dt и ne, как написано выше
+dt = 0.01 # lambda
+# dx = 0.1 # lambda
+dy = 0.14 # lambda
+dz = 0.14 # lambda
+
+# длина волны лазерного импульса
+lambda = 1 um # default: cm; possible: um; lambda_p
+
+# концентрация электронов; используется при добавлении частиц при
+# включенном движущемся окне, а также при расчёте шага по x, если он
+# не задан явно
+ne = 100 ncr # default: cm^{-3}; possible: ncr
+
+# размеры области моделирования
+xlength = 20 # default: lambda; possible: um, fs
+ylength = 12 # default: lambda; possible: um
+zlength = 12 # default: lambda; possible: um
+
+# время моделирования
+t_end = 50 # default: lambda; possible: um, mm, cm
+# период вывода данных в файл
+output_period = 1 # default: lambda; possible: um, mm, cm, t_end
+
+# тип огибающей лазерного импульса
+f_envelope = cos # default: cos, possible: focused, sscos, focussedSSC, pearl, tophat
+# по умолчанию лазерные импульсы распространяются к центру области
+# моделирования (если не заданы ytarget, ztarget); b_sign = -1 меняет направление 
+# магнитного поля импульсов и, следовательно, их направление распространения на
+# противоположное
+b_sign = -1 # default: 1, possible: -1
+# размеры лазерного импульса (в перетяжке)
+xsigma = 3 # default: lambda; possible: um, fs
+ysigma = 2.7 # default: lambda; possible: um
+zsigma = 2.7 # default: lambda; possible: um
+# координаты центра лазерного импульса относительно центра области (или "цели", если заданы xtarget, ytarget, ztarget)
+x0 = 5 # default: lambda; possible: um, fs
+y0 = 0 # default: 0; default units: lambda; possible: um
+z0 = 0 # default: 0; default units: lambda; possible: um
+a0y = 2500
+
+# движущееся окно; выключается при наличии нейтральных потоков (flows)
+mwindow = on # default: on; possible: on, off, auto
+# включает или отключает добавление электронов на передней границе области
+# при работе движущегося окна; таким образом, при mw_mcr = 0 ионы считаюстя неподвижными
+mwseed = on # default: on; possible: on, off
+# Mass-to-charge ratio of the ions (in that for the protons); turns ions on; if mwseed is on, and
+# mw_mcr is non-zero, such ions are added on the right boundary of the simulation box while the box
+# is moving.
+mw_mcr = 2 # default: 0
+
+
+# включение ионов (только для плёнок)
+ions = on # default: off; possible: on (uses mcr), positrons (mcr is ignored, ions are initiated as positrons)
+
+# компоненты полей для вывода в файл
+e_components_for_output = xyz # default: none; possible: x, y, z, xy, xz, yz, xyz
+b_components_for_output = xyz # default: none; possible: x, y, z, xy, xz, yz, xyz
+# компоненты тока для вывода в файл
+j_components_for_output = none # default: none; possible: x, y, z, xy, xz, yz, xyz
+# расстояние от правой границы области до плоскости yz, данные в
+# которой выводятся в файл;
+x0fout = 5 # default value: xlength/2; default units: lambda; possible: um, fs
+
+# число рядов частиц в ячейке по координатам
+xnpic = 1
+ynpic = 1
+znpic = 1
+
+# сорта частиц, данные о которых следует выводить в файл
+particles_for_output = epph # default: e; possible: e, ep, eph, epph
+
+# шаг по энергии в спектре, число точек в спектре и отношение общего
+# числа частиц к числу частиц, все характеристики которых выводятся в
+# файл, для разных сортов частиц
+deps = 4 MeV # default: MeV; possible: mc^2
+neps = 700
+enthp = 200
+#deps_p = 0.5 MeV # default value = deps; default units: MeV; possible: mc^2
+#neps_p = 140 # default = neps
+#enthp_p = 1 # default = enthp
+#deps_ph = 0.5 MeV # default value = deps; default units: MeV; possible: mc^2
+#neps_ph = 800 # default = neps
+#enthp_ph = 10 # default = enthp
+# шаг по энергии в ионном спектре в MeV на нуклон
+deps_i = 2
+neps_i = 1200 # default = neps
+#enthp_i = 10 # default = enthp
+
+# алгоритм слияния квазичастиц; nl - nonlinear(q), ti -
+# type-independently
+pmerging = ti # default: off; possible: nl, ti
+# критическое отношение числа квазичастиц одного сорта к числу ячеек
+crpc = 2.0
+
+# включение и выключение КЭД-эффектов
+qed = on # default: on; possible: off
+
+# выбор пушера частиц
+pusher = vay # default: vay; possible: boris
+
+# выбор метода моделирования ЭМ поля
+solver = ndfx # default: ndfx; possible: fdtd
+
+# имя папки для результатов
+data_folder = results_radiation_trapping_ne_100_a0_2500 # default: results
+
+# режим вывода данных в файл (пока что только для плотности частиц и компонент
+# электромагнитных полей)
+output_mode = binary # default: text; possible: binary
+

--- a/quill3d/main.cpp
+++ b/quill3d/main.cpp
@@ -40,6 +40,7 @@ double file_name_accuracy;
 bool mwseed;
 moving_window mwindow;
 double mwtolerance; // the relative level of E^2 + B^2 causing the window to move in the AUTO mode
+std::string mwseed_ions;
 double mw_mcr;
 double crpc;
 double* ppd;
@@ -1784,10 +1785,39 @@ void add_moving_window_particles()
                     if (modifier != 0.0)
                     {
                         psr->fill_cell_by_particles(-1,cell_pos,v_npic,n*modifier);
-                        if (mw_mcr != 0) {
-                            psr->fill_cell_by_particles( 1 / (proton_mass * mw_mcr)
-                                                       , cell_pos, v_npic, n * modifier);
-                        }
+                    }
+                }
+            }
+        }
+        if (mwseed_ions == "on") {
+            double n;
+            n=1/(k0*k0);
+            n *= lin_interpolation((nmw-1)*dx, ne_profile_x_coords, ne_profile_x_values);
+
+            int_vector3d cell_pos;
+            cell_pos.i = nx_sr[n_sr-1] - 3;
+            int_vector3d v_npic;
+            v_npic.i = xnpic;
+            v_npic.j = ynpic;
+            v_npic.k = znpic;
+            for(int j=0;j<int(ylength/dy);j++)
+            {
+                for(int k=0;k<int(zlength/dz);k++)
+                {
+                    cell_pos.j=j;
+                    cell_pos.k=k;
+                    double zcell = k * dz;
+                    double ycell = j * dy;
+                    double ycenter = ylength / 2.0;
+                    double zcenter = zlength / 2.0;
+                    double zrel = zcell - zcenter;
+                    double yrel = ycell - ycenter;
+                    double r = sqrt(zrel * zrel + yrel * yrel);
+                    double modifier = lin_interpolation(r, ne_profile_r_coords, ne_profile_r_values);
+                    if (modifier != 0.0)
+                    {
+                        psr->fill_cell_by_particles( 1 / (proton_mass * mw_mcr)
+                                                   , cell_pos, v_npic, n * modifier);
                     }
                 }
             }
@@ -2937,8 +2967,14 @@ int init()
     current = find("mwseed",first);
     mwseed = 1;
     if (current->units=="off") mwseed = 0;
+    current = find("mwseed_ions", first);
+    mwseed_ions = current->units;
+    if (mwseed_ions == "")
+        mwseed_ions = "off"; // default
     current = find("mw_mcr", first);
     mw_mcr = current->value;
+    if (mw_mcr == 0)
+        mw_mcr = 1; // default
     current = find("e_components_for_output", first);
     e_components_for_output = current->units;
     current = find("b_components_for_output", first);
@@ -3035,12 +3071,6 @@ int init()
     phib = current->value;
     current = find("ions",first);
     ions = current->units;
-    if (ions=="") {
-        if (mw_mcr == 0 || mwseed == 0)
-            ions = "off";
-        else
-            ions = "on";
-    }
     p_last_film = 0;
     film* tmp_p_film;
     std::string tmp_s;
@@ -3251,7 +3281,7 @@ int init()
             n++;
         if (nerflow!=0)
             n++;
-        if (mwindow == moving_window::ON && mwseed == 1 && mw_mcr != 0) {
+        if (mwindow == moving_window::ON && mwseed_ions == "on") {
             n++;
         }
         double* mcr = new double[n];
@@ -3296,7 +3326,7 @@ int init()
                 m++;
             }
         }
-        if (mwseed == 1 && mw_mcr != 0) {
+        if (mwseed_ions == "on") {
             bool b = 1;
             for (int i = 0; i < m; i++) {
                 b = b && (mcr[i] != mw_mcr);
@@ -3631,11 +3661,15 @@ int init()
         } else if (mwindow==moving_window::AUTO) {
             fout_log<<"mwindow\n"<<"auto"<<"\n";
         }
-        if (mwseed==0)
-            fout_log<<"mwseed\n"<<"off"<<"\n";
-        else
-            fout_log<<"mwseed\n"<<"on"<<"\n";
-        fout_log << "mw_mcr\n" << mw_mcr << '\n';
+        if (mwindow != moving_window::OFF) {
+            if (mwseed==0)
+                fout_log<<"mwseed\n"<<"off"<<"\n";
+            else
+                fout_log<<"mwseed\n"<<"on"<<"\n";
+            fout_log << "mwseed_ions\n" << mwseed_ions << '\n';
+            if (mwseed_ions == "on")
+                fout_log << "mw_mcr\n" << mw_mcr << '\n';
+        }
         fout_log<<"e_components_for_output\n"<<e_components_for_output<<"\n";
         fout_log<<"b_components_for_output\n"<<b_components_for_output<<"\n";
         if (sscos==0) {


### PR DESCRIPTION
New config parameter mw_mcr. It is mass-to-charge ratio of the ions (in that for the protons). If non-zero, it turns ions on (if mwseed is on), and ions are added on the right boundary of the simulation box while the box is moving.